### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,8 @@ enable_language(CXX)
 find_package(SMB REQUIRED)
 find_package(Kodi REQUIRED)
 find_package(p8-platform REQUIRED)
-find_package(kodiplatform REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
-                    ${kodiplatform_INCLUDE_DIRS}
                     ${p8-platform_INCLUDE_DIRS}
                     ${SMB_INCLUDE_DIRS})
 
@@ -29,7 +27,7 @@ set(SMB_SOURCES src/SMBSession.cpp
                 src/netbios/netbios_query.cpp
                 src/netbios/netbios_utils.cpp)
 
-set(DEPLIBS ${SMB_LIBRARIES} ${p8-platform_LIBRARIES} ${kodiplatform_LIBRARIES})
+set(DEPLIBS ${SMB_LIBRARIES} ${p8-platform_LIBRARIES})
 
 add_definitions(-D_LARGEFILE64_SOURCE
                 -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
The vfs.smb2 binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt.