### PR TITLE
Fix missing header include

### DIFF
--- a/src/SMBSession.h
+++ b/src/SMBSession.h
@@ -17,6 +17,7 @@ extern "C"
 
 #include <chrono>
 #include <fcntl.h>
+#include <functional>
 #include <list>
 #include <map>
 #include <mutex>


### PR DESCRIPTION
Fixes compilation with Visual Studio 2019 and 2022

NOTE: Jenkins has been updated to VS 2019 and now fails to build this addon and is not included in nightly Kodi installers.

```
01:51:22 Scanning dependencies of target vfs.smb2
01:51:22 [ 16%] Building CXX object CMakeFiles/vfs.smb2.dir/src/SMBSession.cpp.obj
01:51:22 SMBSession.cpp
01:51:22 D:\jenkins\workspace\WIN-UWP-64\cmake\addons\output\include\smb2/smb2.h(581): warning C4200: nonstandard extension used: zero-sized array in struct/union
01:51:22 D:\jenkins\workspace\WIN-UWP-64\cmake\addons\output\include\smb2/smb2.h(581): note: This member will be ignored by a defaulted constructor or copy/move assignment operator
01:51:22 D:\jenkins\workspace\WIN-UWP-64\cmake\addons\build\vfs.smb2\src\SMBSession.h(102): error C2039: 'function': is not a member of 'std'
01:51:22 C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\mutex(30): note: see declaration of 'std'
01:51:22 D:\jenkins\workspace\WIN-UWP-64\cmake\addons\build\vfs.smb2\src\SMBSession.h(102): error C2143: syntax error: missing ';' before '<'
01:51:22 D:\jenkins\workspace\WIN-UWP-64\cmake\addons\build\vfs.smb2\src\SMBSession.h(102): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
01:51:22 D:\jenkins\workspace\WIN-UWP-64\cmake\addons\build\vfs.smb2\src\SMBSession.h(102): error C2238: unexpected token(s) preceding ';'
01:51:22 D:\jenkins\workspace\WIN-UWP-64\cmake\addons\build\vfs.smb2\src\SMBSession.h(111): error C2061: syntax error: identifier 'async_func'
```
